### PR TITLE
ebaa-79: criada novas rotas para aceitar apenas IDs das medias

### DIFF
--- a/app/Http/Controllers/MediaController.php
+++ b/app/Http/Controllers/MediaController.php
@@ -26,6 +26,7 @@ class MediaController extends Controller
                 ],
                 'display_name' => 'nullable|string',
                 'description' => 'nullable|string',
+                'order' => 'nullable|integer',
             ]);
 
             $service = new CreateMediaService();
@@ -55,6 +56,7 @@ class MediaController extends Controller
                 ],
                 'display_name' => 'nullable|string',
                 'description' => 'nullable|string',
+                'order' => 'nullable|integer',
             ]);
 
             $service = new UpdateMediaService();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -3,21 +3,18 @@
 namespace App\Http\Controllers;
 
 use App\Extensions\CustomPassword;
+use App\Http\Requests\UserRequest;
 use App\Http\Services\User\CreateUserService;
 use App\Http\Services\User\DeleteUserService;
 use App\Http\Services\User\DisableUserService;
 use App\Http\Services\User\EnableUserService;
 use App\Http\Services\User\QueryUserService;
 use App\Http\Services\User\UpdateUserService;
-use App\Models\Role;
 use App\Repositories\UserRepository;
-use App\Rules\UniqueCpfCnpj;
-use App\Rules\UniqueEmail;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Password as PasswordForReset;
-use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Password;
 
 class UserController extends Controller
@@ -40,7 +37,7 @@ class UserController extends Controller
         return $service->getUserById($id);
     }
 
-    public function create(Request $request)
+    public function create(UserRequest $request)
     {
         Gate::authorize('create', auth()->user());
 
@@ -49,32 +46,7 @@ class UserController extends Controller
 
             $service = new CreateUserService();
 
-            $validated = $request->validate([
-                'password' => [
-                    'required', Password::min(6)->mixedCase()->letters()->numbers()
-                ],
-                'role_id' => ['required', 'int', Rule::exists(Role::class, 'id')],
-                'person' => 'array|required',
-                'person.name' => 'required|string',
-                'person.email' => ['required', 'email', new UniqueEmail(new UserRepository())],
-                'person.cpf_cnpj' => ['required', 'string', new UniqueCpfCnpj(new UserRepository())],
-                'person.phone' => 'nullable|string',
-                'person.profile_picture_id' => 'nullable|int',
-                'person.address_id' => 'nullable|int',
-                'person.address' => 'nullable|array',
-                'person.address.id' => 'nullable|int',
-                'person.address.zip' => 'required|string',
-                'person.address.street' => 'required|string',
-                'person.address.number' => 'nullable|string',
-                'person.address.neighborhood' => 'nullable|string',
-                'person.address.city' => 'nullable|string',
-                'person.address.state' => 'nullable|string',
-                'person.address.complement' => 'nullable|string',
-                'person.address.longitude' => 'nullable|string',
-                'person.address.latitude' => 'nullable|string',
-            ]);
-
-            $user = $service->create($validated);
+            $user = $service->create($request->all());
 
             DB::commit();
 
@@ -94,33 +66,7 @@ class UserController extends Controller
 
             $service = new UpdateUserService();
 
-            $validated = $request->validate([
-                'password' => [
-                    'nullable', Password::min(6)->mixedCase()->letters()->numbers()
-                ],
-                'role_id' => ['required', 'int', Rule::exists(Role::class, 'id')],
-                'person' => 'array|required',
-                'person.id' => 'required|int',
-                'person.name' => 'required|string',
-                'person.email' => ['required', 'email', new UniqueEmail(new UserRepository())],
-                'person.cpf_cnpj' => ['required', 'string', new UniqueCpfCnpj(new UserRepository())],
-                'person.phone' => 'nullable|string',
-                'person.profile_picture_id' => 'nullable|int',
-                'person.address_id' => 'nullable|int',
-                'person.address' => 'nullable|array',
-                'person.address.id' => 'nullable|int',
-                'person.address.zip' => 'required|string',
-                'person.address.street' => 'required|string',
-                'person.address.number' => 'nullable|string',
-                'person.address.neighborhood' => 'nullable|string',
-                'person.address.city' => 'nullable|string',
-                'person.address.state' => 'nullable|string',
-                'person.address.complement' => 'nullable|string',
-                'person.address.longitude' => 'nullable|string',
-                'person.address.latitude' => 'nullable|string',
-            ]);
-
-            $updated = $service->update($validated, $id);
+            $updated = $service->update($request->all(), $id);
 
             DB::commit();
 

--- a/app/Http/Requests/EventRequest.php
+++ b/app/Http/Requests/EventRequest.php
@@ -12,6 +12,7 @@ class EventRequest extends FormRequest
         return [
             'name' => 'required|string',
             'description' => 'nullable|string',
+            'location' => 'nullable|string',
             'medias' => 'array|required',
             'medias.*.media' => [
                 'required', File::types(['jpg', 'jpeg', 'png'])

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Repositories\UserRepository;
+use App\Rules\UniqueCpfCnpj;
+use App\Rules\UniqueEmail;
+use App\Rules\ValidateCpfCnpj;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
+
+class UserRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'password' => [
+                'required', Password::min(6)->mixedCase()->letters()->numbers()
+            ],
+            'role_id' => ['required', 'int', Rule::exists(Role::class, 'id')],
+            'person' => 'array|required',
+            'person.name' => 'required|string',
+            'person.email' => [
+                'required',
+                'email',
+                new UniqueEmail(new UserRepository()),
+
+            ],
+            'person.cpf_cnpj' => [
+                'required',
+                'string',
+                new UniqueCpfCnpj(new UserRepository()),
+                new ValidateCpfCnpj($this->request->get('cpf_cnpj'))
+
+            ],
+            'person.phone' => 'nullable|string',
+            'person.profile_picture_id' => 'nullable|int',
+            'person.address_id' => 'nullable|int',
+            'person.address' => 'nullable|array',
+            'person.address.id' => 'nullable|int',
+            'person.address.zip' => 'required|string',
+            'person.address.street' => 'required|string',
+            'person.address.number' => 'nullable|string',
+            'person.address.neighborhood' => 'nullable|string',
+            'person.address.city' => 'nullable|string',
+            'person.address.state' => 'nullable|string',
+            'person.address.complement' => 'nullable|string',
+            'person.address.longitude' => 'nullable|string',
+            'person.address.latitude' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Services/Animal/CreateAnimalService.php
+++ b/app/Http/Services/Animal/CreateAnimalService.php
@@ -12,6 +12,23 @@ class CreateAnimalService
     {
         $repository = new AnimalRepository();
 
+        $mediasIds = collect($data['medias'])
+            ->pluck('id')
+            ->toArray();
+
+        $animal = $repository->create($data);
+        
+        if ($mediasIds) {
+            $animal->medias()->sync($mediasIds);
+        }
+
+        return $animal;
+    }
+
+    public function createWithMedias(array $data)
+    {
+        $repository = new AnimalRepository();
+
         $animal = $repository->create($data);
 
         if (data_get($data, 'medias')) {

--- a/app/Http/Services/Event/CreateEventService.php
+++ b/app/Http/Services/Event/CreateEventService.php
@@ -12,6 +12,23 @@ class CreateEventService
     {
         $repository = new EventRepository();
 
+        $mediasIds = collect($data['medias'])
+            ->pluck('id')
+            ->toArray();
+
+        $event = $repository->create($data);
+
+        if ($mediasIds) {
+            $event->medias()->sync($mediasIds);
+        }
+
+        return $event;
+    }
+
+    public function createWithMedias(array $data)
+    {
+        $repository = new EventRepository();
+
         $event = $repository->create($data);
 
         if (data_get($data, 'medias')) {

--- a/app/Models/Animal.php
+++ b/app/Models/Animal.php
@@ -11,6 +11,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
+
+/**
+ *
+ * @property Adoption $adoption
+ * @property Media $medias
+ */
+
 class Animal extends Model
 {
     use HasFactory;

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -8,6 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+
+/**
+ *
+ * @property Address $address
+ * @property Media $medias
+ */
+
 class Event extends Model
 {
     use HasFactory;

--- a/app/Rules/ValidateCpfCnpj.php
+++ b/app/Rules/ValidateCpfCnpj.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Rules;
+
+use App\Utils\CNPJUtils;
+use App\Utils\CPFUtils;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class ValidateCpfCnpj implements ValidationRule
+{
+    protected $cpfCnpj;
+
+    public function __construct(String $cpfCnpj)
+    {
+        $this->cpfCnpj = $cpfCnpj;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $validate = false;
+        
+        if (strlen($this->cpfCnpj) === 11) {
+            $validate = CPFUtils::validateCpf($this->cpfCnpj);
+        }elseif (strlen($this->cpfCnpj) === 14) {
+            $validate = CNPJUtils::validateCnpj($this->cpfCnpj);
+        }else {
+            $fail('Tamanho incorreto para o campo :attribute');
+        }
+
+        if (!$validate) {
+            $fail(':attribute inválido');
+        }
+    }
+}

--- a/app/Utils/CPFUtils.php
+++ b/app/Utils/CPFUtils.php
@@ -19,7 +19,7 @@ abstract class CPFUtils
         return preg_replace('/[^\da-zA-Z]/', '', $string);
     }
 
-    public function validateCPF($cpf)
+    public static function validateCPF($cpf)
     {
         $cpf = preg_replace( '/[^0-9]/is', '', $cpf );
 

--- a/database/migrations/2024_03_24_001608_create_medias_table.php
+++ b/database/migrations/2024_03_24_001608_create_medias_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->integer('height');
             $table->string('extension', 25);
             $table->text('description')->nullable();
-            $table->integer('order')->nullable()->unique();
+            $table->integer('order')->nullable();
             $table->timestamps();
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -71,6 +71,7 @@ Route::prefix('animals')->group( function() {
             Route::get('/{id}', 'getAnimalById');
 
             Route::post('/', 'create');
+            Route::post('/with-medias', 'createWithMedias');
 
             Route::put('/{id}', 'update');
 
@@ -86,6 +87,7 @@ Route::prefix('events')->group( function() {
             Route::get('/{id}', 'getEventById');
 
             Route::post('/', 'create');
+            Route::post('/with-medias', 'createWithMedias');
 
             Route::put('/{id}', 'update');
 

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -3113,6 +3113,10 @@
                         "description": "Altura da imagem criada",
                         "type": "integer"
                     },
+                    "order": {
+                        "description": "Ordem da imagem",
+                        "type": "integer"
+                    },
                     "created_at": {
                         "description": "Data de criação da imagem criada",
                         "type": "string"


### PR DESCRIPTION
Criada novas rotas para aceitar apenas IDs das medias nos animais e eventos, além de algumas correções gerais