### PR TITLE
ebaa-98: configurando campo type para user e configurando cadastros padrões nas migrations

### DIFF
--- a/app/Enums/UserTypeEnum.php
+++ b/app/Enums/UserTypeEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+enum UserTypeEnum: string
+{
+    case INTERNAL = 'INTERNAL';
+    case EXTERNAL = 'EXTERNAL';
+
+    public static function toArrayWithString(): array
+    {
+        return collect(self::cases())->map( function($case) {
+            return $case->value;
+        })->toArray();
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\UserTypeEnum;
 use App\Extensions\CustomPassword;
 use App\Http\Requests\UserRequest;
 use App\Http\Services\User\CreateUserService;
@@ -46,7 +47,25 @@ class UserController extends Controller
 
             $service = new CreateUserService();
 
-            $user = $service->create($request->all());
+            $user = $service->create($request->all(), null);
+
+            DB::commit();
+
+            return $user;
+        }catch(\Exception $exception) {
+            DB::rollBack();
+            throw new \Exception($exception->getMessage());
+        }
+    }
+
+    public function createExternal(UserRequest $request)
+    {
+        try {
+            DB::beginTransaction();
+
+            $service = new CreateUserService();
+
+            $user = $service->create($request->all(), UserTypeEnum::EXTERNAL);
 
             DB::commit();
 

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\UserTypeEnum;
 use App\Models\Role;
 use App\Repositories\UserRepository;
 use App\Rules\UniqueCpfCnpj;
@@ -19,7 +20,7 @@ class UserRequest extends FormRequest
             'password' => [
                 'required', Password::min(6)->mixedCase()->letters()->numbers()
             ],
-            'role_id' => ['required', 'int', Rule::exists(Role::class, 'id')],
+            'role_id' => ['nullable', 'int', Rule::exists(Role::class, 'id')],
             'person' => 'array|required',
             'person.name' => 'required|string',
             'person.email' => [
@@ -49,6 +50,7 @@ class UserRequest extends FormRequest
             'person.address.complement' => 'nullable|string',
             'person.address.longitude' => 'nullable|string',
             'person.address.latitude' => 'nullable|string',
+            'type' => ['nullable', Rule::in(UserTypeEnum::cases())],
         ];
     }
 }

--- a/app/Models/People.php
+++ b/app/Models/People.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class People extends Model
 {
@@ -27,5 +28,10 @@ class People extends Model
     public function profilePicture(): BelongsTo
     {
         return $this->belongsTo(Media::class);
+    }
+
+    public function person(): HasOne
+    {
+        return $this->hasOne(User::class);
     }
 }

--- a/app/Models/PermissionRole.php
+++ b/app/Models/PermissionRole.php
@@ -17,7 +17,8 @@ class PermissionRole extends Pivot
      * @var array<int, string>
      */
     protected $fillable = [
-        'name',
+        'role_id',
+        'permission_id',
     ];
 
     public function role(): BelongsTo

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -32,6 +32,7 @@ class User extends Authenticatable implements JWTSubject, CanResetPasswordContra
         'status',
         'role_id',
         'people_id',
+        'type',
     ];
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,11 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Enums\UserTypeEnum;
 use App\Models\People;
 use App\Models\Role;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
@@ -32,6 +32,7 @@ class UserFactory extends Factory
             'password' => static::$password ??= Hash::make('password'),
             'people_id' => $person->id,
             'role_id' => $role->id,
+            'type' => UserTypeEnum::INTERNAL
         ];
     }
 }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\UserStatusEnum;
+use App\Enums\UserTypeEnum;
 use App\Models\People;
 use App\Models\Role;
 use Illuminate\Database\Migrations\Migration;
@@ -19,6 +20,7 @@ return new class extends Migration
             $table->foreignIdFor(Role::class);
             $table->foreignIdFor(People::class);
             $table->enum('status', UserStatusEnum::toArrayWithString())->default(UserStatusEnum::ENABLED);
+            $table->enum('type', UserTypeEnum::toArrayWithString());
             $table->string('password');
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2024_04_25_015042_add_default_roles.php
+++ b/database/migrations/2024_04_25_015042_add_default_roles.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Permission;
+use App\Models\PermissionRole;
+use App\Models\Role;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+
+        $adminRole = Role::create([
+            'name' => 'admin',
+        ]);
+
+        Role::create([
+            'name' => 'user'
+        ]);
+
+        foreach (Permission::all() as $permission) {
+            PermissionRole::create([
+                'permission_id' => $permission->id,
+                'role_id' => $adminRole->id,
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $model = Role::whereName('admin')->first();
+
+        if ($model) {
+            foreach ($model->permissions() as $permission) {
+                $model->permissions()->detach($permission->id);
+            }
+
+            $model->delete();
+        }
+    }
+};

--- a/database/migrations/2024_04_25_015043_add_admin_user.php
+++ b/database/migrations/2024_04_25_015043_add_admin_user.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Enums\UserTypeEnum;
+use App\Models\People;
+use App\Models\Permission;
+use App\Models\PermissionRole;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Hash;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $person = People::create([
+            'name' => 'Administrador',
+            'email' => 'admin@teste.com',
+            'cpf_cnpj' => '123.456.789-10',
+        ]);
+
+        $role = Role::whereName('admin')->first();
+
+        foreach (Permission::all() as $permission) {
+            PermissionRole::create([
+                'role_id' => $role->id,
+                'permission_id' => $permission->id,
+            ]);
+        }
+
+        User::create([
+            'password' => Hash::make('Pw12345678!'),
+            'people_id' => $person->id,
+            'role_id' => $role->id,
+            'type' => UserTypeEnum::INTERNAL,
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $model = People::whereEmail('admin@teste.com')->first();
+
+        if ($model) {
+            foreach ($model->user->permissions() as $permission) {
+                $model->user->permissions()->detach($permission->id);
+            }
+
+            $model->user->delete();
+            $model->delete();
+        }
+    }
+};

--- a/database/migrations/2024_04_25_015043_add_default_ngr.php
+++ b/database/migrations/2024_04_25_015043_add_default_ngr.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\Address;
+use App\Models\Ngr;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $address = Address::create([
+            'street' => 'Avenida Centenário',
+            'neighborhood' => 'Centro',
+            'city' => 'Criciúma',
+            'state' => 'SC',
+            'number' => '1000',
+        ]);
+
+        Ngr::create([
+            'name' => 'Patinhas Carentes',
+            'cnpj' => '84.058.017/0001-90',
+            'description' => 'Ong que sonha em fazer a diferença na vida dos animais necessitados na cidade de Criciúma',
+            'address_id' => $address->id
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $model = Ngr::whereName('Patinhas Carentes')->first();
+
+        if ($model) {
+            $model->address->delete();
+            $model->delete();
+        }
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,15 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\Address;
-use App\Models\Ngr;
-use App\Models\People;
-use App\Models\Permission;
-use App\Models\PermissionRole;
-use App\Models\Role;
-use App\Models\User;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
@@ -19,41 +11,5 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $person = People::factory()->create([
-             'name' => 'Administrador',
-             'email' => 'admin@teste.com',
-        ]);
-
-        $role = Role::factory()->create([
-            'name' => 'admin'
-        ]);
-
-        foreach (Permission::all() as $permission) {
-            PermissionRole::factory()->create([
-                'role_id' => $role->id,
-                'permission_id' => $permission->id,
-            ]);
-        }
-
-        User::factory()->create([
-            'password' => Hash::make('123456'),
-            'people_id' => $person->id,
-            'role_id' => $role->id
-        ]);
-
-        $address = Address::factory()->create([
-            'street' => 'Avenida Centenário',
-            'neighborhood' => 'Centro',
-            'city' => 'Criciúma',
-            'state' => 'SC',
-            'number' => '1000',
-        ]);
-
-        Ngr::factory()->create([
-            'name' => 'Patinhas Carentes',
-            'cnpj' => '84.058.017/0001-90',
-            'description' => 'Ong que sonha em fazer a diferença na vida dos animais necessitados na cidade de Criciúma',
-            'address_id' => $address->id
-        ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,6 +47,7 @@ Route::prefix('users')->group( function() {
         Route::middleware('api')->group(function () {
             Route::post('/forgot-password', 'forgotPassword');
             Route::post('/reset-password', 'resetPassword');
+            Route::post('/external', 'createExternal');
         });
     });
 });


### PR DESCRIPTION
Foi criado um novo campo enum "type" para salvar se usuário é interno ou externo e também foi criada novas migrations para criar os cadastros bases para o projeto